### PR TITLE
Use native nfs volumes instead of docker sync

### DIFF
--- a/spaceport
+++ b/spaceport
@@ -36,5 +36,6 @@ $app->add(new Spaceport\Commands\CleanCommand());
 $app->add(new Spaceport\Commands\PhpCommand());
 $app->add(new Spaceport\Commands\RefreshVendorCommand());
 $app->add(new Spaceport\Commands\SelfUpdateCommand());
+$app->add(new Spaceport\Commands\SetupNfsCommand());
 
 $app->run();

--- a/src/Spaceport/Commands/RefreshVendorCommand.php
+++ b/src/Spaceport/Commands/RefreshVendorCommand.php
@@ -13,7 +13,7 @@ class RefreshVendorCommand extends AbstractCommand
     {
         $this
             ->setName('vendor')
-            ->setDescription('Runs a composer install on the container and copies the files back to the host.')
+            ->setDescription('Runs a composer install on the container.')
         ;
     }
 
@@ -21,11 +21,9 @@ class RefreshVendorCommand extends AbstractCommand
     {
         $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
 
-        $this->logStep("Initializing vendor folder on container and copying them onto the host.");
+        $this->logStep("Initializing vendor folder on container.");
         $this->logWarning("This can be a potentially long process.");
         $this->runCommand('docker exec $(docker-compose ps -q php) composer install');
-        $this->runCommand('docker cp $(docker-compose ps -q php):/app/vendor vendor_sync/');
-        $this->runCommand('rm -rf vendor && mv vendor_sync vendor');
-        $this->logSuccess("Vendor folder initialized and copied to your host system!");
+        $this->logSuccess("Vendor folder initialized!");
     }
 }

--- a/src/Spaceport/Commands/SetupNfsCommand.php
+++ b/src/Spaceport/Commands/SetupNfsCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Spaceport\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+class SetupNfsCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('setup-nfs')
+            ->setDescription('Setup local nfs setings')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (\PHP_OS !== 'Darwin') {
+            $output->writeln('This command should only be executed on OS X');
+            exit(1);
+        }
+
+        $nfsConfigCheck = new Process('grep -- "nfs.server.mount.require_resv_port = 0" "/etc/nfs.conf"');
+        $nfsConfigCheck->run();
+
+        if ($nfsConfigCheck->getExitCode() === 0) {
+            $output->writeln('<info>Nfs config has the required settings</info>');
+
+            return;
+        }
+
+        $output->write('Setup required nfs settings...');
+
+        $nfsConfigCommand = 'grep -q -- "nfs.server.mount.require_resv_port = 0" "/etc/nfs.conf" ';
+        $nfsConfigCommand .= '|| echo "nfs.server.mount.require_resv_port = 0" ';
+        $nfsConfigCommand .= '| sudo tee -a /etc/nfs.conf > /dev/null';
+
+        $nsfConfigCheck = new Process($nfsConfigCommand);
+        $nsfConfigCheck->run();
+
+        if ($nsfConfigCheck->getExitCode() === 0) {
+            $output->writeLn('<info>OK</info>');
+        } else {
+            $output->write('<error>FAILED</error>');
+        }
+
+        $output->write('Restarting nfs daemon...');
+
+        $nfsdRestart = new Process('sudo nfsd restart');
+        $nfsdRestart->run();
+
+        if ($nfsdRestart->getExitCode() === 0) {
+            $output->writeLn('<info>OK</info>');
+        } else {
+            $output->write('<error>FAILED</error>');
+        }
+    }
+}

--- a/src/Spaceport/Commands/StopCommand.php
+++ b/src/Spaceport/Commands/StopCommand.php
@@ -43,8 +43,7 @@ class StopCommand extends AbstractCommand
     private function stopProjectContainers()
     {
         $this->logStep("Stopping project containers");
-        $serverInfo = php_uname('s');
-        if (strpos($serverInfo, 'Darwin') !== false && file_exists(parent::DOCKER_COMPOSE_MAC_FILE_NAME)) {
+        if (\PHP_OS === 'Darwin' && file_exists(parent::DOCKER_COMPOSE_MAC_FILE_NAME)) {
             $this->runCommand('docker-compose -f ' . parent::DOCKER_COMPOSE_MAC_FILE_NAME . ' stop');
         } else {
             $this->runCommand('docker-compose -f ' . parent::DOCKER_COMPOSE_LINUX_FILE_NAME . ' stop');

--- a/templates/symfony/docker-compose-mac.yml.twig
+++ b/templates/symfony/docker-compose-mac.yml.twig
@@ -6,8 +6,7 @@ services:
         links:
             - php
         volumes:
-            - .:/app:cached
-            - app:/app:rw
+            - "nfsmount:/app"
         hostname: {{ shuttle.apacheVhost }}
         environment:
             VIRTUAL_HOST: {{ shuttle.apacheVhost }},~^{{ shuttle.name }}\..*\.xip\.io
@@ -19,37 +18,10 @@ services:
             FALLBACK_DOMAIN: {{ shuttle.apacheFallbackDomain ~ '\n' }}
             {%- endif %}
 
-    bg-sync:
-        image: cweagans/bg-sync
-        volumes:
-            - .:/source:rw
-            - app:/app:rw
-        environment:
-            SYNC_DESTINATION: /app
-            SYNC_MAX_INOTIFY_WATCHES: 40000
-            SYNC_VERBOSE: 1
-            SYNC_PREFER: newer
-            SYNC_EXTRA_UNISON_PROFILE_OPTS: |
-              ignore = Name .DS_Store
-              ignore = Name *.tmp
-              ignore = Name .unison.*
-              ignore = Name .idea
-              ignore = Name .git
-              ignore = Name node_modules
-              ignore = Name web/uploads
-              ignore = Name .sass-cache
-              ignore = Name var/cache
-              ignore = Name app/cache
-              ignore = Name vendor
-              ignore = Name vendor_sync
-              ignore = Name bin
-              ignorenot = Name bin/console
-        privileged: true
     php:
         image: kunstmaan/spaceport-php:{{ shuttle.phpVersion }}
         volumes:
-            - .:/app:cached
-            - app:/app:rw
+            - "nfsmount:/app"
             - ~/.ssh/id_rsa:/root/.ssh/id_rsa:ro
             - ~/.composer:/root/.composer
         links:
@@ -83,7 +55,7 @@ services:
     node:
         image: kunstmaan/spaceport-npm:node-{{ shuttle.nodeVersion }}-alpine
         volumes:
-            - app:/src:rw
+            - "nfsmount:/app"
             - ~/.ssh/id_rsa:/root/.ssh/id_rsa:ro
             - ~/.npm:/root/.npm
 
@@ -92,6 +64,12 @@ volumes:
     {{- 'mysqldata_' ~ database.mysqlDatabase }}: {}
     {% endfor %}
     {{- 'app' }}: {}
+    nfsmount:
+        driver: local
+        driver_opts:
+            type: nfs
+            o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+            device: ":${PWD}"
 
 networks:
     isolated_maildev:


### PR DESCRIPTION
See https://medium.com/@sean.handley/how-to-set-up-docker-for-mac-with-native-nfs-145151458adc

To get it up and running you should do the following:

- Run spaceport setup-nfs (only 1 time to setup the correct settings)
- Run spaceport start in a project (all the other settings get setup automatically)

I will provide another PR with a diagnose command to provide a command to debug a problem (missing nfsd, incorrect settings, etc)

The blogpost does a setup so nfs mounts the root project directory /Users. But this messes things up on some occasions, so I did the setup the same a vagrant by creating a `/etc/exports` entry for each project path. This will avoid any conflicts

TODO:
- [ ] Make sure `/etc/exports` paths don't overlap (manual check)
- [x] Setup nfs command recheck
- [x] ~~Check if `/etc/exports` file exists~~ No problem as the command will pipe the info into the file or create it when it doesn't exist
- [x] ~~spaceport start prints "error", but continues (empty `/etc/exports` or specific line not found by grep check?)~~ Fixed by running the grep commands in quite mode
- [ ] Docker restart during startup can timeout if it takes 60 sec or longer. So move the restart to async and let the while look check?
- [ ] Check if exports path's don't overlap. If so don't add the path to exports (project with a docker project in vendor)
- [x] Modify npm container config to also use nfsmount instead of old/remove docker-sync app mount