### PR TITLE
add port 8080 export to dinghy

### DIFF
--- a/src/Spaceport/Commands/StartCommand.php
+++ b/src/Spaceport/Commands/StartCommand.php
@@ -120,7 +120,7 @@ class StartCommand extends AbstractCommand
         //Check if http-proxy container is present
         if (empty($containerId)) {
             $this->logStep('Starting proxy');
-            $this->runCommand('docker run -d --restart=always -v /var/run/docker.sock:/tmp/docker.sock:ro -v ~/.dinghy/certs:/etc/nginx/certs -p 80:80 -p 443:443 -p 19322:19322/udp -e CONTAINER_NAME=http-proxy -e DOMAIN_TLD=dev.kunstmaan.be --name http-proxy codekitchen/dinghy-http-proxy');
+            $this->runCommand('docker run -d --restart=always -v /var/run/docker.sock:/tmp/docker.sock:ro -v ~/.dinghy/certs:/etc/nginx/certs -p 80:80 -p 443:443 -p 8080:80 -p 19322:19322/udp -e CONTAINER_NAME=http-proxy -e DOMAIN_TLD=dev.kunstmaan.be --name http-proxy codekitchen/dinghy-http-proxy');
 
             return;
         }


### PR DESCRIPTION
on testdevides the xip.io url on port 80 will not connect. It seems that docker doesn't 'export' that port publicly. So adding the port 8080 is a temporary solution to access it on testdevices via .xip.io:8080